### PR TITLE
update to cats 0.7.2 and algbra 0.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVe
 val gh = GitHubSettings(org = "non", proj = "alleycats", publishOrg = "org.typelevel", license = mit)
 val devs = Seq(Dev("Erik Osheim", "non"))
 
-val vers = typelevel.versions ++ alleycats.versions + ("discipline" -> "0.4.1")
+val vers = typelevel.versions ++ alleycats.versions
 val libs = typelevel.libraries ++ alleycats.libraries
 val addins = typelevel.scalacPlugins ++ alleycats.scalacPlugins
 val vAll = Versions(vers, libs, addins)
@@ -52,7 +52,7 @@ lazy val coreJVM = coreM.jvm
 lazy val coreJS  = coreM.js
 lazy val coreM   = module("core", CrossType.Pure)
   .settings(typelevel.macroCompatSettings(vAll):_*)
-  .settings(addLibs(vAll, "cats-core", "export-hook", "simulacrum"):_*)
+  .settings(addLibs(vAll, "algebra", "cats-core", "export-hook", "simulacrum"):_*)
 
 /**
  * Laws project

--- a/core/src/main/scala/alleycats/Pure.scala
+++ b/core/src/main/scala/alleycats/Pure.scala
@@ -21,6 +21,7 @@ object Pure extends Pure0 {
       def pure[A](a: A): F[A] = p.pure(a)
       override def map[A, B](fa: F[A])(f: A => B): F[B] = fm.map(fa)(f)
       def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = fm.flatMap(fa)(f)
+      def tailRecM[A, B](a: A)(f: (A) => F[Either[A, B]]): F[B] = fm.tailRecM(a)(f)
     }
 }
 

--- a/core/src/main/scala/alleycats/std/set.scala
+++ b/core/src/main/scala/alleycats/std/set.scala
@@ -38,11 +38,14 @@ object SetInstances {
         val bldr = Set.newBuilder[B]
 
         @tailrec def go(set: Set[Either[A, B]]): Unit = {
-          var lefts: Set[A] = Set()
-          set.foreach {
-            case Right(b) => bldr += b
-            case Left(a) =>
-              lefts = lefts + a
+          val lefts = set.foldLeft(Set[A]()) { (memo, either) =>
+            either.fold(
+              memo + _,
+              b => {
+                bldr += b
+                memo
+              }
+            )
           }
           if(lefts.isEmpty)
             ()

--- a/core/src/main/scala/alleycats/std/set.scala
+++ b/core/src/main/scala/alleycats/std/set.scala
@@ -44,10 +44,12 @@ object SetInstances {
             case Left(a) =>
               lefts = lefts + a
           }
-          go(lefts.flatMap(f))
+          if(lefts.isEmpty)
+            ()
+          else
+            go(lefts.flatMap(f))
         }
         go(f(a))
-
         bldr.result()
       }
     }

--- a/core/src/main/scala/alleycats/std/try.scala
+++ b/core/src/main/scala/alleycats/std/try.scala
@@ -43,12 +43,7 @@ object TryInstances {
       def coflatMap[A, B](fa: Try[A])(f: Try[A] => B): Try[B] = Try(f(fa))
       def extract[A](p: Try[A]): A = p.get
 
-      @tailrec def tailRecM[A, B](a: A)(f: (A) => Try[Either[A, B]]): Try[B] =
-        f(a) match {
-          case e: Failure[_] => e.asInstanceOf[Try[B]]
-          case Success(Left(a1)) => tailRecM(a1)(f)
-          case Success(Right(b)) => Success(b)
-        }
+      def tailRecM[A, B](a: A)(f: (A) => Try[Either[A, B]]): Try[B] = cats.instances.try_.catsStdInstancesForTry.tailRecM(a)(f)
     }
 }
 

--- a/laws/src/main/scala/alleycats/laws/discipline/FlatMapRecTests.scala
+++ b/laws/src/main/scala/alleycats/laws/discipline/FlatMapRecTests.scala
@@ -1,0 +1,28 @@
+package alleycats.laws.discipline
+
+import cats._
+import cats.laws.FlatMapLaws
+import cats.laws.discipline._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+
+
+trait FlatMapRecTests[F[_]] extends Laws {
+  def laws: FlatMapLaws[F]
+
+  def tailRecM[A: Arbitrary](implicit
+                             ArbFA: Arbitrary[F[A]],
+                             EqFA: Eq[F[A]]
+                            ): RuleSet = {
+    new DefaultRuleSet(
+      name = "flatMapTailRec",
+      parent = None,
+      "tailRecM consistent flatMap" -> forAll(laws.tailRecMConsistentFlatMap[A] _))
+  }
+}
+
+object FlatMapRecTests {
+  def apply[F[_]: FlatMap]: FlatMapRecTests[F] =
+    new FlatMapRecTests[F] { def laws: FlatMapLaws[F] = FlatMapLaws[F] }
+}

--- a/project/AlleycatsDeps.scala
+++ b/project/AlleycatsDeps.scala
@@ -10,6 +10,7 @@ object Dependencies {
   // Versions for libraries and packages
   // Package -> version
   val versions = Map[String, String](
+    "discipline" -> "0.4.1"
   )
 
   // library definitions and links to their versions

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,3 @@
-
-resolvers += Resolver.url(
-  "tpolecat-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
-        Resolver.ivyStylePatterns)
-
-resolvers += Resolver.url("typelevel-sbt-plugins", url("http://dl.bintray.com/content/typelevel/sbt-plugins"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.11")
+addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.12")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ resolvers += Resolver.url(
 
 resolvers += Resolver.url("typelevel-sbt-plugins", url("http://dl.bintray.com/content/typelevel/sbt-plugins"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.10")
+addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.11")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/tests/src/test/scala/alleycats/tests/AlleycatsSuite.scala
+++ b/tests/src/test/scala/alleycats/tests/AlleycatsSuite.scala
@@ -5,7 +5,7 @@ package tests
 import catalysts.Platform
 
 import cats._
-import cats.std.AllInstances
+import cats.instances.AllInstances
 import cats.syntax.{AllSyntax, EqOps}
 
 import org.scalactic.anyvals.{PosZDouble, PosInt, PosZInt}
@@ -43,7 +43,7 @@ trait AlleycatsSuite extends FunSuite with Matchers with GeneratorDrivenProperty
 
   // disable Eq syntax (by making `catsSyntaxEq` not implicit), since it collides
   // with scalactic's equality
-  def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
+  override def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 }
 
 sealed trait TestInstances {

--- a/tests/src/test/scala/alleycats/tests/SetTests.scala
+++ b/tests/src/test/scala/alleycats/tests/SetTests.scala
@@ -1,0 +1,14 @@
+package alleycats.tests
+
+import alleycats.laws.discipline._
+
+import alleycats.std.all._
+
+class SetsTests extends AlleycatsSuite {
+
+  checkAll("FlatMapRec[Set]", FlatMapRecTests[Set].tailRecM[Int])
+
+}
+
+
+


### PR DESCRIPTION
Notes
1. sbt-catalysts 0.1.11 is not released yet (https://github.com/typelevel/sbt-catalysts/pull/4), so this won't pass travis. I have a checken-egg problem here (please see the sbt-catalysts PR). So the plan I am thinking is to merge both projects within a short timespan. We'll release sbt-catalysts first and merge this one and release it. 
2. please check my `tailRecM` implementations, it's a bit scary to be lawless here. Any suggestions? 
